### PR TITLE
Use MetadataDirective to replace file onto itself.

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -34,6 +34,7 @@ batchStatusGSI = 'LambdaVerticaBatchStatus';
 filesTable = 'LambdaVerticaProcessedFiles';
 conditionCheckFailed = 'ConditionalCheckFailedException';
 provisionedThroughputExceeded = 'ProvisionedThroughputExceededException';
+replace = "REPLACE";
 
 /* defaults for setup.js */
 REQD_BLANK = 'Reqd.';

--- a/reprocessBatch.js
+++ b/reprocessBatch.js
@@ -64,7 +64,8 @@ var processFile = function(index) {
 			var copySpec = {
 				Bucket : bucketName,
 				Key : fileKey,
-				CopySource : batchEntries[index]
+			        CopySource : batchEntries[index],
+				MetadataDirective: replace
 			};
 			s3.copyObject(copySpec, function(err, data) {
 				if (err) {


### PR DESCRIPTION
Without this, S3 raises an error, because

  You cannot copy an object to itself unless the MetadataDirective header is specified and its value set to REPLACE.

  Source: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html#RESTObjectCOPY-requests
